### PR TITLE
add prev-kv to options to support deletes

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -7,7 +7,7 @@ import (
 )
 
 func buffer(ctx context.Context, l *Listener) State {
-	wC := l.Client.Watcher.Watch(ctx, l.Prefix, etcd.WithPrefix())
+	wC := l.Client.Watcher.Watch(ctx, l.Prefix, etcd.WithPrefix(), etcd.WithPrevKV())
 	l.eC = Stream(ctx, wC)
 	l.logger.Debug().Msg("now buffering events")
 	return Snapshot


### PR DESCRIPTION
This PR adds an option to provide the previous KV value on each GET or WATCH update. 